### PR TITLE
Finalize file sink for BasicMerger::AddSorted before propagating any error

### DIFF
--- a/supersonic/cursor/core/sort.cc
+++ b/supersonic/cursor/core/sort.cc
@@ -349,8 +349,10 @@ class BasicMerger : public Merger {
         THROW(new Exception(ERROR_NOT_IMPLEMENTED,
                             "BasicMerger doesn't handle WAITING_ON_BARRIER."));
       }
+      // Make sure to finalize the file sink before propagating write_all_result
+      FailureOrVoid file_sink_finalize_result = file_sink->Finalize();
       PROPAGATE_ON_FAILURE(write_all_result);
-      PROPAGATE_ON_FAILURE(file_sink->Finalize());
+      PROPAGATE_ON_FAILURE(file_sink_finalize_result);
     }
     // TODO(user): Don't just ignore the util::Status object!
     // We didn't opensource util::task::Status.


### PR DESCRIPTION
If there's an error in the IO path (sort spills on disk) this finalize code will crash (due to assertion).
