### PR TITLE
Memory errors are to high of a log level

### DIFF
--- a/supersonic/base/memory/memory.cc
+++ b/supersonic/base/memory/memory.cc
@@ -47,16 +47,16 @@ void BufferAllocator::LogAllocation(size_t requested,
                                     size_t minimal,
                                     Buffer* buffer) {
   if (buffer == NULL) {
-    LOG(WARNING) << "Memory allocation failed in Supersonic. "
-                 << "Number of bytes requested: " << requested
-                 << ", minimal: " << minimal;
+    VLOG(0) << "Memory allocation failed in Supersonic. "
+            << "Number of bytes requested: " << requested
+            << ", minimal: " << minimal;
     return;
   }
   if (buffer->size() < requested) {
-    LOG(WARNING) << "Memory allocation warning in Supersonic. "
-                 << "Number of bytes requested to allocate: " << requested
-                 << ", minimal: " << minimal
-                 << ", and actually allocated: " << buffer->size();
+    VLOG(0) << "Memory allocation warning in Supersonic. "
+            << "Number of bytes requested to allocate: " << requested
+            << ", minimal: " << minimal
+            << ", and actually allocated: " << buffer->size();
   }
 }
 

--- a/supersonic/base/memory/memory.h
+++ b/supersonic/base/memory/memory.h
@@ -867,14 +867,15 @@ size_t Quota<thread_safe>::Allocate(const size_t requested,
     } else {
       allocation = 0;
     }
-    LOG(WARNING) << "Out of quota. Requested: " << requested
-                 << " bytes, or at least minimal: " << minimal
-                 << ". Current quota value is: " << quota
-                 << " while current usage is: " << usage_
-                 << ". The quota is " << (enforced() ? "" : "not ")
-                 << "enforced. "
-                 << ((allocation == 0) ? "Did not allocate any memory."
-                 : "Allocated the minimal value requested.");
+
+    VLOG(0) << "Out of quota. Requested: " << requested
+            << " bytes, or at least minimal: " << minimal
+            << ". Current quota value is: " << quota
+            << " while current usage is: " << usage_
+            << ". The quota is " << (enforced() ? "" : "not ")
+            << "enforced. "
+            << ((allocation == 0) ? "Did not allocate any memory."
+                                  : "Allocated the minimal value requested.");
   } else {
     allocation = min(requested, quota - usage_);
   }


### PR DESCRIPTION
Right now the code will spam the log file with memory errors anytime we're doing a large (32GB) HybridGroupAggregate / HybridSort operation whenever it reaches the threshold to spill to disk
